### PR TITLE
Add mixmax:smart-disconnect package

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -50,3 +50,4 @@ shell-server@0.2.3
 dispatch:mocha-phantomjs
 modules@0.8.2
 underscore
+mixmax:smart-disconnect

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -69,6 +69,7 @@ meteorhacks:collection-utils@1.2.0
 minifier-css@1.2.16
 minifier-js@2.0.0
 minimongo@1.0.23
+mixmax:smart-disconnect@0.0.4
 mizzao:autocomplete@0.5.1
 mizzao:timesync@0.3.4
 mizzao:user-status@0.6.6


### PR DESCRIPTION
Pretty straightforward package - adds an event listener on visibility change to call Meteor.disconnect() after 60 seconds, or reconnect if disconnected. Hopefully reducing the number of active connections on bc-triage will resolve some of the ongoing performance/crashing issues. 